### PR TITLE
Vagrant Environment Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .sass-cache
+.vagrant
 tmp/*
 log/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "modules/wordpress"]
+	path = modules/wordpress
+	url = https://github.com/jonhadfield/puppet-wordpress.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     guard-compass (0.0.6)
       compass (>= 0.10.5)
       guard (>= 0.2.1)
-    rb-fsevent (0.4.3.1)
+    rb-fsevent (0.9.2)
     sass (3.1.12)
     thor (0.14.6)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This theme is a work is progress for [RockyRoadBlog](http://rockyroadblog.com)
 
 ## Development
 
+Follow the instructions for installing [Vagrant](http://vagrantup.com/)
+
 ````
+vagrant up
 bundle
 bundle exec guard
 rake deploy

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant::Config.run do |config|
+  config.vm.box = "base"
+
+  # Forward a port from the guest to the host, which allows for outside
+  # computers to access the VM, whereas host only networking does not.
+  config.vm.forward_port 80, 8080
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  config.vm.provision :puppet do |puppet|
+    puppet.module_path    = "modules"
+    puppet.manifests_path = "manifests"
+    puppet.manifest_file  = "base.pp"
+  end
+end

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,0 +1,17 @@
+group { "puppet":
+  ensure => "present",
+}
+
+File { owner => 0, group => 0, mode => 0644 }
+file { '/etc/motd':
+  content => "Welcome to your Vagrant-built virtual machine!
+              Managed by Puppet.\n"
+}
+
+# include nginx
+# nginx::resource::vhost { 'rockyroadblog.com':
+#   ensure   => present,
+#   www_root => '/var/www/rockyroadblog.com',
+# }
+
+include wordpress

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -15,3 +15,16 @@ file { '/etc/motd':
 # }
 
 include wordpress
+
+file { '/opt/wordpress/wp-content/themes/rockyroad':
+   ensure => 'link',
+   target => '/vagrant',
+}
+
+# Wordpress uploads
+file { "/opt/wordpress/wp-content/uploads":
+    ensure => "directory",
+    owner  => "root",
+    group  => "root",
+    mode   => 777,
+}


### PR DESCRIPTION
- add [vagrant](http://vagrantup.com/)
- provision with [puppet](http://puppetlabs.com/)
- add [puppet-wordpress](https://github.com/jonhadfield/puppet-wordpress)
- symlink `/vagrant` to `/opt/wordpress/wp-content/themes/rockyroad`
- mkdir 755 `/opt/wordpress/wp-content/uploads`
