### PR TITLE
Resolve rockyroadblog.vagrant DNS for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+.bundle
 .DS_Store
 .sass-cache
 .vagrant
+bin/
 tmp/*
 log/*
+vendor/gems

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,11 @@
 source 'http://rubygems.org'
 
+gem 'rake'
 gem 'compass'
 gem 'guard'
 gem 'guard-compass'
 gem 'guard-bundler'
 gem 'growl'
 gem 'rb-fsevent'
+gem 'vagrant'
+gem 'vagrant-dns'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,17 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    archive-tar-minitar (0.5.2)
+    childprocess (0.3.6)
+      ffi (~> 1.0, >= 1.0.6)
     chunky_png (1.2.5)
     compass (0.11.6)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
+    daemons (1.1.9)
+    erubis (2.7.0)
+    eventmachine (1.0.0)
     ffi (1.0.11)
     fssm (0.2.8)
     growl (1.0.3)
@@ -18,9 +24,35 @@ GEM
     guard-compass (0.0.6)
       compass (>= 0.10.5)
       guard (>= 0.2.1)
+    i18n (0.6.1)
+    json (1.5.4)
+    log4r (1.1.10)
+    net-scp (1.0.4)
+      net-ssh (>= 1.99.1)
+    net-ssh (2.2.2)
+    rainbow (1.1.4)
+    rake (10.0.3)
     rb-fsevent (0.9.2)
+    rexec (1.5.1)
+      rainbow
+    rubydns (0.5.3)
+      eventmachine (~> 1.0.0)
+      rexec (~> 1.5.1)
     sass (3.1.12)
     thor (0.14.6)
+    vagrant (1.0.5)
+      archive-tar-minitar (= 0.5.2)
+      childprocess (~> 0.3.1)
+      erubis (~> 2.7.0)
+      i18n (~> 0.6.0)
+      json (~> 1.5.1)
+      log4r (~> 1.1.9)
+      net-scp (~> 1.0.4)
+      net-ssh (~> 2.2.2)
+    vagrant-dns (0.3.0)
+      daemons
+      rubydns (~> 0.5.3)
+      vagrant
 
 PLATFORMS
   ruby
@@ -31,4 +63,7 @@ DEPENDENCIES
   guard
   guard-bundler
   guard-compass
+  rake
   rb-fsevent
+  vagrant
+  vagrant-dns

--- a/README.md
+++ b/README.md
@@ -6,14 +6,25 @@ This theme is a work is progress for [RockyRoadBlog](http://rockyroadblog.com)
 
 Follow the instructions for installing [Vagrant](http://vagrantup.com/)
 
-````
-vagrant up
-bundle
-bundle exec guard
-rake deploy
-````
+```sh
+$ script/bootstrap
+$ open 'http://rockyroadblog.vagrant'
+```
 
-## Directories and Files
+[vagrant-dns](https://github.com/BerlinVagrant/vagrant-dns) is run locally on
+[port 5300 to route requests to the VM.
+
+## Deployment
+
+To deploy the site, run:
+
+```sh
+$ rake deploy
+```
+
+This rsync this theme files over to the server.
+
+## Files
 
 * index.php - main wordpress page
 * style.css - theme definition file

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,14 @@
 Vagrant::Config.run do |config|
   config.vm.box = "base"
 
+  config.dns.tld = "vagrant"
+
+  config.vm.host_name = "rockyroadblog"
+
+  config.dns.patterns = [/^.*rockyroadblog.vagrant$/]
+
+  config.vm.network :hostonly, "33.33.33.60"
+
   # Forward a port from the guest to the host, which allows for outside
   # computers to access the VM, whereas host only networking does not.
   config.vm.forward_port 80, 8080

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Installing gem dependencies..."
+bundle install --binstubs --path vendor/gems
+
+echo "Installing rockyroadblog.vagrant dns..."
+sudo vagrant dns --install
+
+echo "Booting vagrant vm..."
+vagrant up
+
+bin/guard


### PR DESCRIPTION
Similar to [pow](http://pow.cx), we're using [vagrant-
dns](https://github.com/BerlinVagrant/vagrant-dns) to simplify development.
This also adds a `script/bootstrap` to simplify initial setup.
