### PR TITLE
Backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 tmp/*
 log/*
 vendor/gems
+uploads

--- a/script/db-pull
+++ b/script/db-pull
@@ -8,3 +8,6 @@ mysql -uroot wordpress <<SQL
 update wp_options set option_value = 'http://rockyroadblog.vagrant' where option_name = 'siteurl';
 update wp_options set option_value = 'http://rockyroadblog.vagrant' where option_name = 'home';
 SQL
+
+echo "Pulling down images..."
+rsync -avz --human-readable --times jch@whatcodecraves.com:/var/www/wp-uploads/rockyroadblog.com uploads


### PR DESCRIPTION
There's 3 parts to backup:
- uploads stored at `/var/www/wp-uploads`
- themes and wordpress code stored at `/usr/share/wordpress` (aliased as `/var/www/rockroadblog.com`)
- mysql database `wordpress`

Debian's wordpress package set uploads strangely instead of keeping it in the same folder. It's editable in the settings, but breaks images.
